### PR TITLE
feat: Set academicMeta.startMonday to 2025-08-04

### DIFF
--- a/index.html
+++ b/index.html
@@ -458,7 +458,7 @@
       const academicMeta = {
         initialized: false,
         startWeekKey: null,
-        startMonday: null,
+        startMonday: "2025-08-04",
         skipSet: new Set(),
         skipMondays: [],
       };

--- a/index.html
+++ b/index.html
@@ -458,7 +458,7 @@
       const academicMeta = {
         initialized: false,
         startWeekKey: null,
-        startMonday: "2025-08-04",
+        startMonday: new Date(Date.UTC(2025, 7, 4)),
         skipSet: new Set(),
         skipMondays: [],
       };

--- a/index.html
+++ b/index.html
@@ -514,7 +514,7 @@
         if (wkMon < academicMeta.startMonday) return null;
         // Compute raw week offset
         const diffWeeks = Math.round(
-          (wkMon - academicMeta.startMonday) / (7 * 24 * 60 * 60 * 1000),
+          (wkMon - academicMeta.startMonday) / (7 * 24 * 60 * 60 * 1000) + 1,
         );
         // Count skip weeks up to (and including if itself a skip) this Monday
         let skipsUpTo = 0;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Academic calendar now initializes with a predefined start Monday, so academic week numbers and weekday/skip behavior are computed immediately on first load.
  * Prevents blank or inconsistent week displays and improves reliability of week-based views and scheduling from initial load.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->